### PR TITLE
WIP (1/2) Properly support camera orientation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+qtubuntu-camera (0.3.5+ubports1) xenial; urgency=medium
+
+  * Properly support camera orientation.
+    - Remove orientation corrections when using front camera.
+    - Invert camera orientation given from Android HAL.
+    - Add a camera orientation override for some devices.
+
+ -- Ratchanan Srirattanamet <peathot@hotmail.com>  Sun, 16 Jun 2019 02:58:36 +0700
+
 qtubuntu-camera (0.3.4+ubports) xenial; urgency=medium
 
   * Imported to UBports

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends: debhelper (>= 9),
                qt5-default,
                qtmultimedia5-dev,
                libpulse-dev,
-               libexiv2-dev
+               libexiv2-dev,
+               libandroid-properties-dev
 Standards-Version: 3.9.4
 Homepage: https://launchpad.net/qtubuntu-camera
 # If you aren't a member of ~phablet-team but need to upload packaging changes,

--- a/src/aalcameraserviceplugin.cpp
+++ b/src/aalcameraserviceplugin.cpp
@@ -96,7 +96,16 @@ int AalServicePlugin::cameraOrientation(const QByteArray & device) const
     }
 
     int result = android_camera_get_device_info(deviceID, &facing, &orientation);
-    return (result != 0) ? 0 : orientation;
+    if (result != 0) {
+        return 0;
+    }
+
+    // Android's orientation means differently compared to QT's orientation.
+    // On Android, it means "the angle that the camera image needs to be
+    // rotated", but on QT, it means "the physical orientation of the camera
+    // sensor". So, the value will have to be inverted.
+
+    return (360 - orientation) % 360;
 }
 
 QCamera::Position AalServicePlugin::cameraPosition(const QByteArray & device) const

--- a/src/aalcameraserviceplugin.cpp
+++ b/src/aalcameraserviceplugin.cpp
@@ -17,13 +17,25 @@
 #include "aalcameraserviceplugin.h"
 #include "aalcameraservice.h"
 
+#include <QString>
 #include <QDebug>
 #include <QMetaType>
 #include <qgl.h>
 
+#include <hybris/properties/properties.h>
 #include <hybris/camera/camera_compatibility_layer.h>
 #include <hybris/camera/camera_compatibility_layer_capabilities.h>
 
+static QString getAndroidDeviceCodename() {
+    char deviceCodename[PROP_VALUE_MAX];
+
+    int result = property_get("ro.product.device", deviceCodename, "");
+    if (result != 0) {
+        return QString();
+    }
+
+    return QString(deviceCodename);
+}
 
 AalServicePlugin::AalServicePlugin()
 {
@@ -98,6 +110,22 @@ int AalServicePlugin::cameraOrientation(const QByteArray & device) const
     int result = android_camera_get_device_info(deviceID, &facing, &orientation);
     if (result != 0) {
         return 0;
+    }
+
+    if (facing == FRONT_FACING_CAMERA_TYPE) {
+        QString deviceCodename = getAndroidDeviceCodename();
+
+        if (deviceCodename == "krillin" || deviceCodename == "vegetahd") {
+            // krillin / vegetahd lies to us - the top of the front facing camera
+            // points to the right of the screen (viewed from the front), which means
+            // the camera image needs rotating by 270deg with the device in its natural
+            // orientation (portrait). It tells us the camera orientation is 90deg
+            // though (see https://launchpad.net/bugs/1567542)
+            // https://git.launchpad.net/oxide/tree/shared/browser/media/oxide_video_capture_device_hybris.cc#n92
+
+            // FIXME: is this the right place to do this?
+            orientation = 270;
+        }
     }
 
     // Android's orientation means differently compared to QT's orientation.

--- a/src/aalimagecapturecontrol.cpp
+++ b/src/aalimagecapturecontrol.cpp
@@ -80,7 +80,7 @@ int AalImageCaptureControl::capture(const QString &fileName)
     m_captureCancelled = false;
 
     AalMetaDataWriterControl* metadataControl = m_service->metadataWriterControl();
-    int rotation = metadataControl->correctedOrientation();
+    int rotation = metadataControl->orientation();
     android_camera_set_rotation(m_service->androidControl(), rotation);
 
     android_camera_take_snapshot(m_service->androidControl());

--- a/src/aalmediarecordercontrol.cpp
+++ b/src/aalmediarecordercontrol.cpp
@@ -467,7 +467,7 @@ int AalMediaRecorderControl::startRecording()
     setParameter(PARAM_AUDIO_CHANNELS, 2);
     setParameter(PARAM_AUTIO_SAMPLING, 96000);
     if (m_service->metadataWriterControl()) {
-        int rotation = m_service->metadataWriterControl()->correctedOrientation();
+        int rotation = m_service->metadataWriterControl()->orientation();
         setParameter(PARAM_ORIENTATION, rotation);
         m_service->metadataWriterControl()->clearAllMetaData();
     }

--- a/src/aalmetadatawritercontrol.cpp
+++ b/src/aalmetadatawritercontrol.cpp
@@ -89,27 +89,13 @@ void AalMetaDataWriterControl::setMetaData(const QString &key, const QVariant &v
 }
 
 /*!
- * \brief AalMetaDataWriterControl::orientation returns the orientation of the device, as set by the
+ * \brief AalMetaDataWriterControl::orientation returns the orientation of the camera, as set by the
  * app in degrees.
  * \return orientation, set by the app. Defaults is 0
  */
 int AalMetaDataWriterControl::orientation() const
 {
     return m_orientation;
-}
-
-/*!
- * \brief AalMetaDataWriterControl::correctedOrientation returns the orientation
- * depending on which camera is active, the value is adapted
- * \return
- */
-int AalMetaDataWriterControl::correctedOrientation() const
-{
-    int rotation = m_orientation % 360;
-    // the front camera rotates the other way round
-    if (!m_service->isBackCameraUsed())
-        rotation = (360 - rotation) % 360;
-    return rotation;
 }
 
 /*!

--- a/src/aalmetadatawritercontrol.h
+++ b/src/aalmetadatawritercontrol.h
@@ -43,7 +43,6 @@ public:
     void setMetaData(const QString & key, const QVariant & value);
 
     int orientation() const;
-    int correctedOrientation() const;
 
     void clearAllMetaData();
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -10,7 +10,7 @@ target.path += $$[QT_INSTALL_PLUGINS]/$${PLUGIN_TYPE}
 INSTALLS = target
 
 CONFIG += link_pkgconfig
-PKGCONFIG += exiv2 libqtubuntu-media-signals libmedia libcamera hybris-egl-platform libpulse-simple
+PKGCONFIG += exiv2 libqtubuntu-media-signals libmedia libcamera hybris-egl-platform libpulse-simple libandroid-properties
 
 OTHER_FILES += aalcamera.json
 

--- a/unittests/stubs/aalmetadatawritercontrol_stub.cpp
+++ b/unittests/stubs/aalmetadatawritercontrol_stub.cpp
@@ -55,11 +55,6 @@ int AalMetaDataWriterControl::orientation() const
     return m_orientation;
 }
 
-int AalMetaDataWriterControl::correctedOrientation() const
-{
-    return m_orientation;
-}
-
 void AalMetaDataWriterControl::clearAllMetaData()
 {
 }


### PR DESCRIPTION
There were assumptions about camera orientation in Ubuntu Touch. This PR removes those assumptions and add proper support for camera orientation. It also changes how orientation is communicated from the `camera-app`. Thus, a PR on `camera-app` (not yet developed) is also required. This partially fixes ubports/ubuntu-touch#370.

(Requires ubports/libhybris#16 to be buildable because this package uses pkg-config files.)