### PR TITLE
(1/2) Fix camera video A/V desync

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+qtubuntu-camera (0.4.1+ubports0) xenial; urgency=medium
+
+  * Prevent AudioCapture from sending late samples into /dev/socket/micshm,
+    which will cause A/V desync because micshm doesn't accept timing.
+    This is done by limiting maximum PA buffer size & flush buffer before
+    first read.
+
+ -- Ratchanan Srirattanamet <peathot@hotmail.com>  Fri, 28 Jun 2019 01:12:17 +0700
+
 qtubuntu-camera (0.4.0+ubports0) xenial; urgency=medium
 
   * Correctly report camera orientation by inverting the value given from

--- a/src/audiocapture.cpp
+++ b/src/audiocapture.cpp
@@ -83,6 +83,16 @@ void AudioCapture::run()
         return;
     }
 
+    // To reduce latency, try to flush samples not read before this function is called.
+    {
+        int ret = 0, error = 0;
+        ret = pa_simple_flush(m_paStream, &error);
+        if (ret < 0) {
+            qWarning() << "Failed to flush sample not read before run(): " << pa_strerror(error)
+                       << " (but continuing anyway).";
+        }
+    }
+
     do {
         bytesRead = readMicrophone();
         if (bytesRead > 0)


### PR DESCRIPTION
Prevent AudioCapture from sending late samples into /dev/socket/micshm, which will cause A/V desync because micshm doesn't accept timing. This is done by limiting maximum PA buffer size & flush buffer before first read.

This fixes ubports/ubuntu-touch#1116 to the point usable to most of the users (the audio is still around 300ms behind video on my FP2). With ubports/android_frameworks_av#4, the issue is completely fixed.