### PR TITLE
[WIP] Calculate camera orientation relative to screen

### DIFF
--- a/src/aalcameraserviceplugin.h
+++ b/src/aalcameraserviceplugin.h
@@ -38,6 +38,10 @@ public:
     QString deviceDescription(const QByteArray &service, const QByteArray &device);
     int cameraOrientation(const QByteArray & device) const;
     QCamera::Position cameraPosition(const QByteArray & device) const;
+
+private:
+    int m_screenRotationOffset;
+    void calculateScreenRotationOffset();
 };
 
 #endif


### PR DESCRIPTION
This should fix camera orientation on tablet devices which mount the screen in portrait, such as M10 HD.