### PR TITLE
[WIP] Read orientation overrides from Android property

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qtubuntu-camera (0.4.2+ubports0) xenial; urgency=medium
+
+  * Read orientation overrides from Android property.
+
+ -- Ratchanan Srirattanamet <peathot@hotmail.com>  Mon, 22 Jul 2019 19:44:30 +0700
+
 qtubuntu-camera (0.4.1+ubports0) xenial; urgency=medium
 
   * Prevent AudioCapture from sending late samples into /dev/socket/micshm,

--- a/src/aalcameraserviceplugin.cpp
+++ b/src/aalcameraserviceplugin.cpp
@@ -17,25 +17,13 @@
 #include "aalcameraserviceplugin.h"
 #include "aalcameraservice.h"
 
-#include <QString>
 #include <QDebug>
 #include <QMetaType>
 #include <qgl.h>
 
-#include <hybris/properties/properties.h>
 #include <hybris/camera/camera_compatibility_layer.h>
 #include <hybris/camera/camera_compatibility_layer_capabilities.h>
 
-static QString getAndroidDeviceCodename() {
-    char deviceCodename[PROP_VALUE_MAX];
-
-    int length = property_get("ro.product.device", deviceCodename, "");
-    if (length <= 0) {
-        return QString();
-    }
-
-    return QString(deviceCodename);
-}
 
 AalServicePlugin::AalServicePlugin()
 {
@@ -110,22 +98,6 @@ int AalServicePlugin::cameraOrientation(const QByteArray & device) const
     int result = android_camera_get_device_info(deviceID, &facing, &orientation);
     if (result != 0) {
         return 0;
-    }
-
-    if (facing == FRONT_FACING_CAMERA_TYPE) {
-        QString deviceCodename = getAndroidDeviceCodename();
-
-        if (deviceCodename == "krillin" || deviceCodename == "vegetahd") {
-            // krillin / vegetahd lies to us - the top of the front facing camera
-            // points to the right of the screen (viewed from the front), which means
-            // the camera image needs rotating by 270deg with the device in its natural
-            // orientation (portrait). It tells us the camera orientation is 90deg
-            // though (see https://launchpad.net/bugs/1567542)
-            // https://git.launchpad.net/oxide/tree/shared/browser/media/oxide_video_capture_device_hybris.cc#n92
-
-            // FIXME: is this the right place to do this?
-            orientation = 270;
-        }
     }
 
     // Android's orientation means differently compared to QT's orientation.

--- a/src/aalcameraserviceplugin.h
+++ b/src/aalcameraserviceplugin.h
@@ -18,6 +18,7 @@
 #define AALSERVICEPLUGIN_H
 
 #include <QMediaServiceProviderPlugin>
+#include <QVector>
 
 class AalServicePlugin : public QMediaServiceProviderPlugin,
                          public QMediaServiceSupportedDevicesInterface,
@@ -38,6 +39,9 @@ public:
     QString deviceDescription(const QByteArray &service, const QByteArray &device);
     int cameraOrientation(const QByteArray & device) const;
     QCamera::Position cameraPosition(const QByteArray & device) const;
+
+private:
+    QVector<int> m_orientationOverrides;
 };
 
 #endif


### PR DESCRIPTION
This separate config from code, and make it easier to add overrides for
other devices in the future.