### PR TITLE
SUPER HACK! completly recreate camera hal to restart preview (hammerhead)

### DIFF
--- a/src/aalimagecapturecontrol.h
+++ b/src/aalimagecapturecontrol.h
@@ -80,6 +80,7 @@ private:
     QString m_galleryPath;
     QMediaPlayer *m_audioPlayer;
     QSettings m_settings;
+    std::string m_deviceName;
 
     QMap<DiskWriteWatcher*, int> m_pendingSaveOperations;
 };


### PR DESCRIPTION
This is a massive SUPER HACK! it completely destroy and recreate camera
hal to restart preview. ¯\_(ツ)_/¯

Kinda fixes: https://github.com/ubports/ubuntu-touch/issues/611

Lets keep this open as *last resort* if we don't find a better fix in time