### PR TITLE
Fix prevent overwriting state set while suspended

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -16,8 +19,8 @@ pipeline {
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
               unstash 'source'
               sh '''export architecture="armhf"
-  build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+build-binary.sh'''
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -28,8 +31,8 @@ pipeline {
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
               unstash 'source'
               sh '''export architecture="arm64"
-   build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+    build-binary.sh'''
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ pipeline {
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/src/aalcameracontrol.h
+++ b/src/aalcameracontrol.h
@@ -54,6 +54,15 @@ private:
     QCamera::State m_state;
     QCamera::Status m_status;
     QCamera::CaptureModes m_captureMode;
+
+    bool m_restoreStateWhenApplicationActive;
+    QCamera::State m_cameraStateWhenApplicationActive;
+    Qt::ApplicationState m_previousApplicationState;
+
+    // Used as a slot but not declared as such to avoid problems with unit tests
+    void onApplicationStateChanged();
+    // Used to bypass m_restoreStateWhenApplicationActive
+    void doSetState(QCamera::State state);
 };
 
 #endif

--- a/src/aalcameraservice.cpp
+++ b/src/aalcameraservice.cpp
@@ -34,7 +34,6 @@
 
 #include <hybris/camera/camera_compatibility_layer.h>
 
-#include <QtGui/QGuiApplication>
 #include <QDebug>
 #include <cmath>
 
@@ -43,8 +42,7 @@ AalCameraService *AalCameraService::m_service = 0;
 AalCameraService::AalCameraService(QObject *parent):
     QMediaService(parent),
     m_androidControl(0),
-    m_androidListener(0),
-    m_restoreStateWhenApplicationActive(false)
+    m_androidListener(0)
 {
     m_service = this;
 
@@ -64,11 +62,6 @@ AalCameraService::AalCameraService(QObject *parent):
     m_exposureControl = new AalCameraExposureControl(this);
     m_infoControl = new AalCameraInfoControl(this);
     m_rotationHandler = new RotationHandler(this);
-
-    QGuiApplication* application = qobject_cast<QGuiApplication*>(QGuiApplication::instance());
-    m_previousApplicationState = application->applicationState();
-    connect(application, &QGuiApplication::applicationStateChanged,
-            this, &AalCameraService::onApplicationStateChanged);
 }
 
 AalCameraService::~AalCameraService()
@@ -293,25 +286,6 @@ void AalCameraService::updateCaptureReady()
         ready = false;
 
     m_imageCaptureControl->setReady(ready);
-}
-
-void AalCameraService::onApplicationStateChanged()
-{
-    QGuiApplication* application = qobject_cast<QGuiApplication*>(QGuiApplication::instance());
-    Qt::ApplicationState applicationState = application->applicationState();
-
-    if (applicationState == Qt::ApplicationActive) {
-        if (m_restoreStateWhenApplicationActive) {
-            m_cameraControl->setState(m_cameraStateWhenApplicationActive);
-        }
-    } else if (m_previousApplicationState == Qt::ApplicationActive) {
-        m_cameraStateWhenApplicationActive = m_cameraControl->state();
-        m_restoreStateWhenApplicationActive = true;
-        m_mediaRecorderControl->setState(QMediaRecorder::StoppedState);
-        m_cameraControl->setState(QCamera::UnloadedState);
-    }
-
-    m_previousApplicationState = applicationState;
 }
 
 /*!

--- a/src/aalcameraservice.h
+++ b/src/aalcameraservice.h
@@ -93,9 +93,6 @@ public:
 public Q_SLOTS:
     void updateCaptureReady();
 
-protected Q_SLOTS:
-    void onApplicationStateChanged();
-
 private:
     void initControls(CameraControl *camControl, CameraControlListener *listener);
 
@@ -121,9 +118,6 @@ private:
 
     StorageManager *m_storageManager;
     RotationHandler *m_rotationHandler;
-    bool m_restoreStateWhenApplicationActive;
-    QCamera::State m_cameraStateWhenApplicationActive;
-    Qt::ApplicationState m_previousApplicationState;
 };
 
 #endif

--- a/unittests/aalcameracontrol/aalcameraservice.cpp
+++ b/unittests/aalcameracontrol/aalcameraservice.cpp
@@ -83,10 +83,6 @@ void AalCameraService::enableVideoMode()
 {
 }
 
-void AalCameraService::onApplicationStateChanged()
-{
-}
-
 void AalCameraService::initControls(CameraControl *camControl, CameraControlListener *listener)
 {
     Q_UNUSED(camControl);

--- a/unittests/aalcameraexposurecontrol/aalcameraservice.cpp
+++ b/unittests/aalcameraexposurecontrol/aalcameraservice.cpp
@@ -79,10 +79,6 @@ bool AalCameraService::isPreviewStarted() const
     return true;
 }
 
-void AalCameraService::onApplicationStateChanged()
-{
-}
-
 void AalCameraService::initControls(CameraControl *camControl, CameraControlListener *listener)
 {
     m_exposureControl->init(camControl, listener);

--- a/unittests/aalcameraflashcontrol/aalcameraservice.cpp
+++ b/unittests/aalcameraflashcontrol/aalcameraservice.cpp
@@ -70,10 +70,6 @@ bool AalCameraService::isPreviewStarted() const
     return true;
 }
 
-void AalCameraService::onApplicationStateChanged()
-{
-}
-
 void AalCameraService::initControls(CameraControl *camControl, CameraControlListener *listener)
 {
     Q_UNUSED(camControl);

--- a/unittests/aalcamerafocuscontrol/aalcameraservice.cpp
+++ b/unittests/aalcamerafocuscontrol/aalcameraservice.cpp
@@ -67,10 +67,6 @@ bool AalCameraService::isPreviewStarted() const
     return true;
 }
 
-void AalCameraService::onApplicationStateChanged()
-{
-}
-
 void AalCameraService::initControls(CameraControl *camControl, CameraControlListener *listener)
 {
     Q_UNUSED(camControl);

--- a/unittests/aalcamerazoomcontrol/aalcameraservice.cpp
+++ b/unittests/aalcamerazoomcontrol/aalcameraservice.cpp
@@ -81,10 +81,6 @@ bool AalCameraService::isPreviewStarted() const
     return true;
 }
 
-void AalCameraService::onApplicationStateChanged()
-{
-}
-
 void AalCameraService::initControls(CameraControl *camControl, CameraControlListener *listener)
 {
     m_zoomControl->init(camControl, listener);

--- a/unittests/aalvideodeviceselectorcontrol/aalcameraservice.cpp
+++ b/unittests/aalvideodeviceselectorcontrol/aalcameraservice.cpp
@@ -75,10 +75,6 @@ bool AalCameraService::isCameraActive() const
     return true;
 }
 
-void AalCameraService::onApplicationStateChanged()
-{
-}
-
 void AalCameraService::initControls(CameraControl *camControl, CameraControlListener *listener)
 {
     Q_UNUSED(camControl);

--- a/unittests/aalviewfindersettingscontrol/aalcameraservice.cpp
+++ b/unittests/aalviewfindersettingscontrol/aalcameraservice.cpp
@@ -68,10 +68,6 @@ bool AalCameraService::isPreviewStarted() const
     return true;
 }
 
-void AalCameraService::onApplicationStateChanged()
-{
-}
-
 void AalCameraService::initControls(CameraControl *camControl, CameraControlListener *listener)
 {
     Q_UNUSED(camControl);

--- a/unittests/stubs/aalcameraservice_stub.cpp
+++ b/unittests/stubs/aalcameraservice_stub.cpp
@@ -76,10 +76,6 @@ void AalCameraService::stopPreview()
 {
 }
 
-void AalCameraService::onApplicationStateChanged()
-{
-}
-
 void AalCameraService::initControls(CameraControl *camControl, CameraControlListener *listener)
 {
     delete m_androidControl;


### PR DESCRIPTION
Due to some unknown race condition, if the application is launched from
the launcher while the screen is locked, the app might set the camera
state after the application state become Suspended. In this case, we
don't want to overwrite the state with the state before suspended when
the app become active again.

The old code assumes that in this case, the app will never become active
before suspended. However, the recent change in QtUbuntu [1] breaks this
assumption. This commit adds another condition: it will not overwrite
the state when the app is active if it's set by the app. This requires
moving the application state handling to CameraControl in order to
distinguish between setting state from the app and from itself.

[1] https://github.com/ubports/qtubuntu/pull/14

Fixes: https://github.com/ubports/ubuntu-touch/issues/1403

This PR comes with Jenkinsfile update.