### PR TITLE
Make AalCameraService advance status as things happen

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qtubuntu-camera (0.5.0+ubports0) xenial; urgency=medium
+
+  * Make AalCameraService advance status as things happen
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Wed, 23 Oct 2019 01:31:22 +0700
+
 qtubuntu-camera (0.4.2+ubports0) xenial; urgency=medium
 
   * Read orientation overrides from Android property

--- a/src/aalcameracontrol.cpp
+++ b/src/aalcameracontrol.cpp
@@ -97,6 +97,11 @@ QCamera::Status AalCameraControl::status() const
     return m_status;
 }
 
+void AalCameraControl::setStatus(QCamera::Status status) {
+    m_status = status;
+    Q_EMIT statusChanged(status);
+}
+
 QCamera::CaptureModes AalCameraControl::captureMode() const
 {
     return m_captureMode;

--- a/src/aalcameracontrol.h
+++ b/src/aalcameracontrol.h
@@ -63,6 +63,9 @@ private:
     void onApplicationStateChanged();
     // Used to bypass m_restoreStateWhenApplicationActive
     void doSetState(QCamera::State state);
+
+    friend AalCameraService;
+    void setStatus(QCamera::Status);
 };
 
 #endif

--- a/src/aalcameraservice.cpp
+++ b/src/aalcameraservice.cpp
@@ -184,6 +184,8 @@ bool AalCameraService::connectCamera()
     m_androidListener->context = m_androidControl;
     initControls(m_androidControl, m_androidListener);
 
+    this->m_cameraControl->setStatus(QCamera::LoadedStatus);
+
     return true;
 }
 
@@ -204,6 +206,8 @@ void AalCameraService::disconnectCamera()
         delete m_androidListener;
         m_androidListener = 0;
     }
+
+    this->m_cameraControl->setStatus(QCamera::UnloadedStatus);
 }
 
 void AalCameraService::startPreview()
@@ -211,6 +215,8 @@ void AalCameraService::startPreview()
     if (m_videoOutput) {
         m_videoOutput->startPreview();
     }
+
+    this->m_cameraControl->setStatus(QCamera::ActiveStatus);
 }
 
 void AalCameraService::stopPreview()
@@ -218,6 +224,8 @@ void AalCameraService::stopPreview()
     if (m_videoOutput) {
         m_videoOutput->stopPreview();
     }
+
+    this->m_cameraControl->setStatus(QCamera::LoadedStatus);
 }
 
 bool AalCameraService::isPreviewStarted() const
@@ -246,10 +254,17 @@ bool AalCameraService::isBackCameraUsed() const
  */
 void AalCameraService::enablePhotoMode()
 {
+    if (isPreviewStarted())
+        // Trick to make applications notice the change.
+        this->m_cameraControl->setStatus(QCamera::StartingStatus);
+
     m_flashControl->init(m_service->androidControl());
     m_imageEncoderControl->enablePhotoMode();
     m_focusControl->enablePhotoMode();
     m_viewfinderControl->setAspectRatio(m_imageEncoderControl->getAspectRatio());
+
+    if (isPreviewStarted())
+        this->m_cameraControl->setStatus(QCamera::ActiveStatus);
 }
 
 /*!
@@ -257,9 +272,16 @@ void AalCameraService::enablePhotoMode()
  */
 void AalCameraService::enableVideoMode()
 {
+    if (isPreviewStarted())
+        // Trick to make applications notice the change.
+        this->m_cameraControl->setStatus(QCamera::StartingStatus);
+
     m_flashControl->init(m_service->androidControl());
     m_focusControl->enableVideoMode();
     m_viewfinderControl->setAspectRatio(m_videoEncoderControl->getAspectRatio());
+
+    if (isPreviewStarted())
+        this->m_cameraControl->setStatus(QCamera::ActiveStatus);
 }
 
 /*!


### PR DESCRIPTION
Previously, the camera's status is never updated because we assume that
state change is synchronous. However, we've learned from other plugins
that it isn't always the case. Applications need to use the status
property to find out if state change is complete or not.

This commit make sure that the status property reflects the actual
status of the camera. This is done by letting AalCameraService tells
AalCameraControl when the service connect/disconnect the camera, start/
stop preview, and when the capture mode is changed. This should cover
all changes in status required.

------------------------------------------------------------------------------------

- The version is bumped because this is a non-breaking behavior change. I would recommend bumping the click framework version too.
- This PR is required to use the gst-droid version of camera-app, which has been modified to rely on status (instead of state).