### PR TITLE
Select JPEG thumbnail size from the list of sizes supported by driver

### DIFF
--- a/src/aalimageencodercontrol.cpp
+++ b/src/aalimageencodercontrol.cpp
@@ -173,6 +173,16 @@ bool AalImageEncoderControl::setSize(const QSize &size)
         } else {
             m_currentThumbnailSize = QSize((int)(128.0f * imageAspectRatio), 128);
         }
+
+        QSize closestSize = m_availableThumbnailSizes[0];
+        foreach (const QSize &size, m_availableThumbnailSizes) {
+            if (abs(size.width() * size.height() - m_currentThumbnailSize.width() * m_currentThumbnailSize.height())
+                    < abs(closestSize.width() * closestSize.height() - m_currentThumbnailSize.width() * m_currentThumbnailSize.height())) {
+                closestSize = size;
+            }
+        }
+        m_currentThumbnailSize = closestSize;
+
         thumbnailAspectRatio = (float)m_currentThumbnailSize.width() / (float)m_currentThumbnailSize.height();
     }
 


### PR DESCRIPTION
On Halium 9 (Volla Phone in particular), having requested JPEG thumbnail size not in the list of supported thumbnail sizes will cause Parameters::set() to fail, making camera application unable to control any other parameters such as rotation/zoom/flashlight/focus/etc:
```
10-04 20:54:23.296 31102 31102 D CameraCompatibilityLayer: Supported thumbnail sizes: 0x0,160x96,192x108,192x144)
10-04 20:54:23.850   103   267 E Camera2-Parameters: set: Requested JPEG thumbnail size 128 x 72 is not supported
```
This attempts to resolve this issue, but I hope not to recreate the original one that part of code was supposed to solve.