### PR TITLE
Log correct filenames, not only the path, on save errors.

### DIFF
--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -243,7 +243,7 @@ SaveToDiskResult StorageManager::saveJpegImage(QByteArray data, QVariantMap meta
         const qint64 writtenSize = file.write(data);
         file.close();
         if (writtenSize != data.size()) {
-            result.errorMessage = QString("Could not write file %1").arg(fileName);
+            result.errorMessage = QString("Could not write file %1").arg(file.fileName());
             return result;
         }
     }
@@ -251,7 +251,7 @@ SaveToDiskResult StorageManager::saveJpegImage(QByteArray data, QVariantMap meta
     QFile finalFile(file.fileName());
     bool ok = finalFile.rename(captureFile);
     if (!ok) {
-        result.errorMessage = QString("Could not save image to %1").arg(fileName);
+        result.errorMessage = QString("Could not save image to %1").arg(captureFile);
         return result;
     }
 


### PR DESCRIPTION
With the Qt 5.12 update, it seems something changed with how temporary files work, and apparmor failures were being caused. When looking at the related code here, I noticed the log messages for errors when saving a photo, were using the wrong filenames, causing the log message to only show the directory path, rather than the actual file names.

These simple changes should fix this.