### PR TITLE
AudioCapture: Add 1 sec timeout for writing audio

### DIFF
--- a/src/audiocapture.cpp
+++ b/src/audiocapture.cpp
@@ -220,9 +220,22 @@ int AudioCapture::writeDataToPipe()
 ssize_t AudioCapture::loopWrite(int fd, const void *data, size_t size)
 {
     ssize_t ret = 0;
+    fd_set set;
+    struct timeval tv;
+
+    tv.tv_sec = 1;
+    tv.tv_usec = 0;
+    FD_ZERO(&set);
+    FD_SET(fd, &set);
+
     while (size > 0)
     {
         ssize_t r;
+        int n = select(fd+1, NULL, &set, NULL, &tv);
+
+        if (!n || n == -1 || m_flagExit)
+            break;
+
         if ((r = write(fd, data, size)) < 0)
             return r;
         if (r == 0)


### PR DESCRIPTION
On the Pixel 3a a race condition can happen when recording
video with audio, which we almost always lose.
This is manifested in the Halium-side RecordThread stopping
whereas the Ubuntu Touch side doesn't know what to do
and hangs at the blocking write to the micshm fifo.

To counter this add a 1 second timeout to the write
to get out of the hanging state and have it exit cleanly.

This fixes hangs when stopping video recording on at
least the Pixel 3a (sargo), and potentially others.