### PR TITLE
Check for new path when using camera shutter sound

### DIFF
--- a/src/aalimagecapturecontrol.cpp
+++ b/src/aalimagecapturecontrol.cpp
@@ -51,7 +51,7 @@ AalImageCaptureControl::AalImageCaptureControl(AalCameraService *service, QObjec
     m_audioPlayer(new QMediaPlayer(this))
 {
     m_galleryPath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
-    m_audioPlayer->setMedia(QUrl::fromLocalFile("/system/media/audio/ui/camera_click.ogg"));
+    m_audioPlayer->setMedia(QUrl::fromLocalFile("/usr/share/sounds/ubports/camera/click/camera_click.ogg"));
     m_audioPlayer->setAudioRole(QAudio::NotificationRole);
 
     QObject::connect(&m_storageManager, &StorageManager::previewReady,


### PR DESCRIPTION
Newer Android versions place the media files in /product/media
instead of /system/media.

Change-Id: Icbc4c041429b9f07635ea6a8492b14ae25c7d1f7
Signed-off-by: Alexander Martinz <alex@amartinz.at>