### PR TITLE
Do not limit to two cameras only, but access/use any of the available ones

### DIFF
--- a/src/aalcameraservice.cpp
+++ b/src/aalcameraservice.cpp
@@ -162,22 +162,7 @@ bool AalCameraService::connectCamera()
 
     m_androidListener = new CameraControlListener;
     memset(m_androidListener, 0, sizeof(*m_androidListener));
-
-    // if there is only one camera fallback directly to the ID of whatever device we have
-    if (m_deviceSelectControl->deviceCount() == 1) {
-        m_androidControl = android_camera_connect_by_id(m_deviceSelectControl->selectedDevice(), m_androidListener);
-    } else {
-        /*
-        CameraType device = BACK_FACING_CAMERA_TYPE;
-        if (!isBackCameraUsed()) {
-            device = FRONT_FACING_CAMERA_TYPE;
-        }
-
-        m_androidControl = android_camera_connect_to(device, m_androidListener);
-        */
-        
-        m_androidControl = android_camera_connect_by_id(m_deviceSelectControl->selectedDevice(), m_androidListener);
-    }
+    m_androidControl = android_camera_connect_by_id(m_deviceSelectControl->selectedDevice(), m_androidListener);
 
     if (!m_androidControl) {
         delete m_androidListener;

--- a/src/aalcameraservice.cpp
+++ b/src/aalcameraservice.cpp
@@ -167,12 +167,16 @@ bool AalCameraService::connectCamera()
     if (m_deviceSelectControl->deviceCount() == 1) {
         m_androidControl = android_camera_connect_by_id(m_deviceSelectControl->selectedDevice(), m_androidListener);
     } else {
+        /*
         CameraType device = BACK_FACING_CAMERA_TYPE;
         if (!isBackCameraUsed()) {
             device = FRONT_FACING_CAMERA_TYPE;
         }
 
         m_androidControl = android_camera_connect_to(device, m_androidListener);
+        */
+        
+        m_androidControl = android_camera_connect_by_id(m_deviceSelectControl->selectedDevice(), m_androidListener);
     }
 
     if (!m_androidControl) {


### PR DESCRIPTION
This MR is an attempt to allow qtubuntu-camera access to all camera devices `QtMultimedia.availableCameras` lists.

In the end this turned out to be a very basic change, removing the original toggling in between the first two devices (if available) and respecting `m_deviceSelectControl->selectedDevice()` instead.

There is space for improvement, like the check for `m_deviceSelectControl->deviceCount() == 1` no longer has to be in place since both if else branches ultimately do the same, we can remove the commented out toggling code etc.

What I think we need to address before merging is the fact I get more available cameras than there actually are, as noted here:
https://github.com/ubports/qtubuntu-camera/issues/20

1. It is not nice co have some dummy devices in place. But I am not sure what's causing it :(
2. Selecting a non-existent device makes any app lose its connection to this stack. It does require closing the app and reopening it, fortunately no system restart, but still not good.

If you want to test this, feel free to try this basic camera devises switching app: https://iubuntu.cz/ut/lenses_0.1_all.click
or even the tweaked Ubports camera app - as outlined in the issue linked above.

Any thoughts are highly appreciated. Thank you :)